### PR TITLE
Set Location header before writing header to response stream

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -126,8 +126,8 @@ func (b *blobHandler) putBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Location", result.Location)
+	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		return
 	}


### PR DESCRIPTION
Note: fixes bug where Location was always empty