### PR TITLE
Don't log nil err when closing reader

### DIFF
--- a/server/storage/gcs/gcs.go
+++ b/server/storage/gcs/gcs.go
@@ -36,8 +36,9 @@ func (d *Driver) GetPayload(ctx context.Context, r *storage.GetRequest) (*storag
 		return nil, err
 	}
 	defer func() {
-		err := reader.Close()
-		log.Printf("unable to close bucket reader: %v", err)
+		if err := reader.Close(); err != nil {
+			log.Printf("unable to close bucket reader: %v", err)
+		}
 	}()
 
 	numBytes, err := io.Copy(r.Writer, reader)


### PR DESCRIPTION
Signed-off-by: grantfuhr <grant.fuhr@datadoghq.com>

On a successful get request using the gcs driver, it is logging a nil err. 