### PR TITLE
chore: Adds GitHub Action based CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: LPS
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.x'
+
+      - name: Print Go version
+        run: go version
+
+      - name: Build binary
+        run: go build -o lps cmd/server/main.go
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Lint code
+        run: |
+          gofmt -l .
+          test -z $(gofmt -l .)

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ In essence, the Large Payload Service implements a [content addressed storage](h
 
 <!-- toc -->
 
-- [Large Payload Service](#large-payload-service)
-  - [Architecture](#architecture)
-  - [Usage](#usage)
-  - [Development](#development)
-    - [Build the Source](#build-the-source)
-    - [Run the Tests](#run-the-tests)
-    - [Format the Code](#format-the-code)
+- [Architecture](#architecture)
+- [Usage](#usage)
+- [Development](#development)
+  * [Build the Source](#build-the-source)
+  * [Run the Tests](#run-the-tests)
+  * [Format the Code](#format-the-code)
+- [CI](#ci)
 
 <!-- tocstop -->
 
@@ -117,4 +117,13 @@ go test ./...
 
 ```sh
 gofmt -l -w .
+```
+
+## CI
+
+CI is configured via a GitHub Workflow in [.github/workflows/ci.yaml](.github/workflows/ci.yaml).
+You can test and run the pipeline locally by installed `[act](https://github.com/nektos/act)` and running:
+
+```shell
+act pull_request
 ```


### PR DESCRIPTION
- Makes driver setup tests work w/o a GCS default credentials file
