### PR TITLE
chore: Refactored e2e test

### DIFF
--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -3,6 +3,8 @@ package server_test
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"math/rand"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -19,28 +21,48 @@ import (
 	"github.com/DataDog/temporal-large-payload-codec/server/storage/memory"
 )
 
+const (
+	largePayloadSize = 5_000_000
+	letterBytes      = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	taskQueue        = "large_payloads"
+)
+
 func Workflow(ctx workflow.Context) error {
 	var result LargePayloadActivityResponse
+
+	bigData := make([]byte, largePayloadSize)
+	for i := range bigData {
+		bigData[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+
+	request := LargePayloadActivityRequest{
+		Data: string(bigData),
+	}
+
 	if err := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToCloseTimeout: time.Second * 5,
-	}), LargePayloadActivity).Get(ctx, &result); err != nil {
+	}), "LargePayloadActivity", request).Get(ctx, &result); err != nil {
 		return err
 	}
 
-	if result.Data != "hello world" {
+	if request.Data != result.Data {
 		return fmt.Errorf("unexpected activity result: %q", result.Data)
 	}
 
 	return nil
 }
 
+type LargePayloadActivityRequest struct {
+	Data string
+}
+
 type LargePayloadActivityResponse struct {
 	Data string
 }
 
-func LargePayloadActivity(ctx context.Context) (LargePayloadActivityResponse, error) {
+func LargePayloadActivity(_ context.Context, req LargePayloadActivityRequest) (LargePayloadActivityResponse, error) {
 	return LargePayloadActivityResponse{
-		Data: "hello world",
+		Data: req.Data,
 	}, nil
 }
 
@@ -53,7 +75,7 @@ func TestWorker(t *testing.T) {
 		codec.WithURL(testCodecServer.URL),
 		codec.WithNamespace("e2e-test"),
 		codec.WithHTTPClient(testCodecServer.Client()),
-		codec.WithMinBytes(32),
+		codec.WithMinBytes(1_000_000),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -62,46 +84,40 @@ func TestWorker(t *testing.T) {
 
 	// Create test Temporal server and client
 	ts := temporaltest.NewServer(temporaltest.WithT(t))
-	c := ts.NewClientWithOptions(client.Options{
+	testClient := ts.NewClientWithOptions(client.Options{
 		DataConverter: testDataConverter,
 	})
 
 	// Register a new worker
-	w := worker.New(c, "large_payloads", worker.Options{})
-	defer w.Stop()
-	w.RegisterWorkflow(Workflow)
-	w.RegisterActivity(LargePayloadActivity)
-	if err := w.Start(); err != nil {
-		t.Fatal(err)
-	}
+	testWorker := worker.New(testClient, taskQueue, worker.Options{})
+	defer testWorker.Stop()
+
+	testWorker.RegisterWorkflow(Workflow)
+	testWorker.RegisterActivity(LargePayloadActivity)
+	err = testWorker.Start()
+	require.NoError(t, err)
 
 	// Start a workflow that executes an activity with a "large" response payload
-	wfr, err := c.ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{
-		TaskQueue:                "large_payloads",
-		WorkflowExecutionTimeout: time.Second * 10,
+	wfr, err := testClient.ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{
+		TaskQueue:                taskQueue,
+		WorkflowExecutionTimeout: time.Second * 60,
 	}, Workflow)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Wait for workflow to complete and fail test if workflow errors.
-	if err := wfr.Get(context.Background(), nil); err != nil {
-		t.Fatal(err)
-	}
+	err = wfr.Get(context.Background(), nil)
+	require.NoError(t, err)
 
 	// Validate that activity result was encoded via remote codec
-	wfHistory := c.GetWorkflowHistory(context.Background(), wfr.GetID(), wfr.GetRunID(), false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	wfHistory := testClient.GetWorkflowHistory(context.Background(), wfr.GetID(), wfr.GetRunID(), false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
 	for wfHistory.HasNext() {
 		event, err := wfHistory.Next()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		t.Log(event.GetEventType().String())
 		if event.GetEventType() == enums.EVENT_TYPE_ACTIVITY_TASK_COMPLETED {
 			payload := event.GetActivityTaskCompletedEventAttributes().GetResult().GetPayloads()[0]
-			if _, ok := payload.GetMetadata()["temporal.io/remote-codec"]; !ok {
-				t.Errorf("activity payload not encoded with remote codec, got: %s", payload.String())
-			}
+			_, ok := payload.GetMetadata()["temporal.io/remote-codec"]
+			require.True(t, ok)
 		}
 	}
 }


### PR DESCRIPTION
The test uses now a larger payload which exceeds the Temporal as well as gRPC limits.
It also passes and returns a large payload to/from the Activity.