### PR TITLE
Unescape URL encoded key parameter on get

### DIFF
--- a/server/handler/v2/handler.go
+++ b/server/handler/v2/handler.go
@@ -14,6 +14,7 @@ import (
 	"hash"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -90,8 +91,12 @@ func (b *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 		b.handleError(w, errors.New("key query parameter is required"), http.StatusBadRequest)
 		return
 	}
+	key, err := url.QueryUnescape(keyParam)
+	if err != nil {
+		b.handleError(w, fmt.Errorf("key query parameter %s cannot be unescaped: %w", keyParam, err), http.StatusBadRequest)
+	}
 
-	if _, err := b.driver.GetPayload(r.Context(), &storage.GetRequest{Key: keyParam, Writer: w}); err != nil {
+	if _, err := b.driver.GetPayload(r.Context(), &storage.GetRequest{Key: key, Writer: w}); err != nil {
 		w.Header().Del("Content-Length") // unset Content-Length on errors
 
 		var blobNotFound *storage.ErrBlobNotFound

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,6 +102,20 @@ func TestGetBlobV2(t *testing.T) {
 			},
 			queryParams: map[string]string{
 				"key": putResponse.Key,
+			},
+			want:       `hello world`,
+			statusCode: http.StatusOK,
+		},
+		{
+			name:   "Successful retrieval while decoding key",
+			target: "blobs/get",
+			method: http.MethodGet,
+			headers: map[string]string{
+				"Content-Type":                      "application/octet-stream",
+				"X-Payload-Expected-Content-Length": "10",
+			},
+			queryParams: map[string]string{
+				"key": url.QueryEscape(putResponse.Key),
 			},
 			want:       `hello world`,
 			statusCode: http.StatusOK,


### PR DESCRIPTION
Some CLI tools like httpie are always encoding URL parameters. If we don't decode the parameter, we end up hitting 404s. This patch properly handles decoding the key parameter when appropriate.