### PR TITLE
feat: add WithCustomHeaders option

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strconv"
 )
 
@@ -165,6 +166,13 @@ func WithCustomHeader(header string, value string) Option {
 	return applier(func(c *Codec) error {
 		if len(header) == 0 {
 			return errors.New("header cannot be empty")
+		}
+		matchesRegex, err := regexp.MatchString("^\\w+(-\\w+)*$", header)
+		if err != nil {
+			return errors.New("unable to validate header")
+		}
+		if !matchesRegex {
+			return errors.New("header has invalid characters")
 		}
 		if c.customHeaders == nil {
 			c.customHeaders = make(map[string][]string)

--- a/codec.go
+++ b/codec.go
@@ -13,14 +13,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
 	"io"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
-
-	"go.temporal.io/api/common/v1"
-	"go.temporal.io/sdk/converter"
 )
 
 const (
@@ -42,6 +41,8 @@ type Codec struct {
 	skipUrlHealthCheck bool
 	// disableEncoding when set to true encoding will be disabled.
 	disableEncoding bool
+	// customHeaders http headers to add the request sent to LargePayloadService
+	customHeaders map[string][]string
 }
 
 type keyResponse struct {
@@ -153,6 +154,26 @@ func WithoutUrlHealthCheck() Option {
 func WithDecodeOnly() Option {
 	return applier(func(c *Codec) error {
 		c.disableEncoding = true
+		return nil
+	})
+}
+
+// WithCustomHeader adds a custom header to append to the http headers of the request sent to LargePayloadService
+// when called with the same header it will not override the header but instead will append to its value.
+// fails when passed an empty header.
+func WithCustomHeader(header string, value string) Option {
+	return applier(func(c *Codec) error {
+		if len(header) == 0 {
+			return errors.New("header cannot be empty")
+		}
+		if c.customHeaders == nil {
+			c.customHeaders = make(map[string][]string)
+		}
+		if _, exists := c.customHeaders[header]; !exists {
+			c.customHeaders[header] = make([]string, 0, 1)
+		}
+
+		c.customHeaders[header] = append(c.customHeaders[header], value)
 		return nil
 	})
 }
@@ -278,6 +299,12 @@ func (c *Codec) encodePayload(ctx context.Context, payload *common.Payload) (*co
 	}
 	req.Header.Set("X-Temporal-Metadata", base64.StdEncoding.EncodeToString(md))
 
+	for header, values := range c.customHeaders {
+		for _, value := range values {
+			req.Header.Add(header, url.QueryEscape(value))
+		}
+	}
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -359,6 +386,11 @@ func (c *Codec) decodePayload(ctx context.Context, payload *common.Payload, vers
 	req.URL.RawQuery = q.Encode()
 
 	req.Header.Set("Content-Type", "application/octet-stream")
+	for header, values := range c.customHeaders {
+		for _, value := range values {
+			req.Header.Add(header, url.QueryEscape(value))
+		}
+	}
 	// TODO: we temporarily need this because we aren't checking object metadata on the server
 	req.Header.Set("X-Payload-Expected-Content-Length", strconv.FormatUint(uint64(remoteP.Size), 10))
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -170,7 +170,7 @@ func Test_codec_sets_custom_headers_when_sending_request_to_lps(t *testing.T) {
 		expectedMultiHeaderKey:  {"VALUE1", "VALUE2"},
 	}
 
-	testSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for header, values := range expectedHeaders {
 			gotValues := r.Header.Values(header)
 			require.Equal(t, values, gotValues)
@@ -178,9 +178,8 @@ func Test_codec_sets_custom_headers_when_sending_request_to_lps(t *testing.T) {
 
 		w.WriteHeader(200)
 	}))
-
-	testSrv.Start()
 	defer testSrv.Close()
+
 	client, err := New(
 		WithURL(testSrv.URL),
 		WithoutUrlHealthCheck(),
@@ -287,7 +286,7 @@ func TestNewCodec(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// with invalid header key
+	// with empty header key
 	client, err = New(
 		WithURL(s.URL),
 		WithHTTPClient(s.Client()),
@@ -298,6 +297,17 @@ func TestNewCodec(t *testing.T) {
 	)
 	require.Error(t, err)
 
+	// with invalid header key
+	client, err = New(
+		WithURL(s.URL),
+		WithHTTPClient(s.Client()),
+		WithNamespace("test"),
+		WithVersion("v2"),
+		WithoutUrlHealthCheck(),
+		WithCustomHeader("invalid header", "VALID_VALUE"),
+	)
+	require.Error(t, err)
+
 	// with valid customHeader
 	client, err = New(
 		WithURL(s.URL),
@@ -305,9 +315,9 @@ func TestNewCodec(t *testing.T) {
 		WithNamespace("test"),
 		WithVersion("v2"),
 		WithoutUrlHealthCheck(),
-		WithCustomHeader("VALID_SINGLE", "VALID_VALUE"),
-		WithCustomHeader("VALID_MULTI", "VALUE_1"),
-		WithCustomHeader("VALID_MULTI", "VALUE_2"),
+		WithCustomHeader("VALID0SINGLE", "VALID_VALUE"),
+		WithCustomHeader("VALID-MULTI", "VALUE_1"),
+		WithCustomHeader("VALID-MULTI", "VALUE_2"),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
added a new option `customHeader`: when set the passed headers will be appended to the headers of the request sent to `LargePayloadService`.