### PR TITLE
fix: health check doesn't add custom headers.

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -182,7 +182,6 @@ func Test_codec_sets_custom_headers_when_sending_request_to_lps(t *testing.T) {
 
 	client, err := New(
 		WithURL(testSrv.URL),
-		WithoutUrlHealthCheck(),
 		WithHTTPClient(testSrv.Client()),
 		WithNamespace("test"),
 		WithMinBytes(32),


### PR DESCRIPTION
This is to add custom header for health check which should have been added in PR : https://github.com/DataDog/temporal-large-payload-codec/pull/74