### PR TITLE
codec: add WithReturnErrorOnIOError option for non-worker callers

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -43,6 +43,10 @@ type Codec struct {
 	skipUrlHealthCheck bool
 	// disableEncoding when set to true encoding will be disabled.
 	disableEncoding bool
+	// returnErrorOnIOError when set to true, IO errors will be returned as errors instead of panicking.
+	// Use this when the codec is used outside of a Temporal worker context (e.g. in an API handler or
+	// a goroutine not managed by the Temporal SDK), where panics are not caught and would crash the process.
+	returnErrorOnIOError bool
 	// customHeaders http headers to add the request sent to LargePayloadService
 	customHeaders map[string][]string
 }
@@ -164,6 +168,22 @@ func WithoutUrlHealthCheck() Option {
 func WithDecodeOnly() Option {
 	return applier(func(c *Codec) error {
 		c.disableEncoding = true
+		return nil
+	})
+}
+
+// WithReturnErrorOnIOError configures the codec to return errors instead of panicking on IO errors.
+//
+// By default the codec panics on IO errors so that the Temporal worker's WorkflowPanicPolicy
+// handles them, avoiding non-determinism issues inside workflow functions.
+//
+// Use this option when the codec is used outside of a Temporal worker context — for example
+// in an API handler, a client-side goroutine, or an activity that fetches a prior workflow
+// result via client.GetWorkflow(...).Get(...). In those contexts the Temporal SDK does not
+// catch panics, so an IO error would crash the process rather than failing a single task.
+func WithReturnErrorOnIOError() Option {
+	return applier(func(c *Codec) error {
+		c.returnErrorOnIOError = true
 		return nil
 	})
 }
@@ -324,21 +344,21 @@ func (c *Codec) encodePayload(ctx context.Context, payload *common.Payload) (*co
 	addCustomHeaders(req, c.customHeaders)
 	resp, err := c.client.Do(req)
 	if err != nil {
-		panicOnIOError(err) // resp is nil when Do fails; panicOnIOError panics before resp.Body is accessed below
+		return nil, c.ioError(err) // resp is nil when Do fails; ioError panics/errors before resp.Body is accessed below
 	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panicOnIOError(err)
+		return nil, c.ioError(err)
 	}
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		panicOnIOError(fmt.Errorf("server returned status code %d: %s", resp.StatusCode, respBody))
+		return nil, c.ioError(fmt.Errorf("server returned status code %d: %s", resp.StatusCode, respBody))
 	}
 
 	var key keyResponse
 	if err := json.Unmarshal(respBody, &key); err != nil {
-		panicOnIOError(fmt.Errorf("unable to unmarshal put response: %w", err)) // key is zero-valued when unmarshal fails; panicOnIOError panics before key.Key is used below
+		return nil, c.ioError(fmt.Errorf("unable to unmarshal put response: %w", err)) // key is zero-valued when unmarshal fails; ioError panics/errors before key.Key is used below
 	}
 
 	result, err := converter.GetDefaultDataConverter().ToPayload(remotePayload{
@@ -410,27 +430,27 @@ func (c *Codec) decodePayload(ctx context.Context, payload *common.Payload, vers
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		panicOnIOError(err) // resp is nil when Do fails; panicOnIOError panics before resp.StatusCode is accessed below
+		return nil, c.ioError(err) // resp is nil when Do fails; ioError panics/errors before resp.StatusCode is accessed below
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		panicOnIOError(fmt.Errorf("server returned status code %d", resp.StatusCode))
+		return nil, c.ioError(fmt.Errorf("server returned status code %d", resp.StatusCode))
 	}
 
 	sha2 := sha256.New()
 	tee := io.TeeReader(resp.Body, sha2)
 	b, err := io.ReadAll(tee)
 	if err != nil {
-		panicOnIOError(err)
+		return nil, c.ioError(err)
 	}
 
 	if uint(len(b)) != remoteP.Size {
-		panicOnIOError(fmt.Errorf("wanted object of size %d, got %d", remoteP.Size, len(b)))
+		return nil, c.ioError(fmt.Errorf("wanted object of size %d, got %d", remoteP.Size, len(b)))
 	}
 
 	checkSum := hex.EncodeToString(sha2.Sum(nil))
 	if fmt.Sprintf("sha256:%s", checkSum) != remoteP.Digest {
-		panicOnIOError(fmt.Errorf("wanted object sha %s, got %s", remoteP.Digest, checkSum))
+		return nil, c.ioError(fmt.Errorf("wanted object sha %s, got %s", remoteP.Digest, checkSum))
 	}
 
 	return &common.Payload{
@@ -439,9 +459,18 @@ func (c *Codec) decodePayload(ctx context.Context, payload *common.Payload, vers
 	}, nil
 }
 
-// panicOnIOError panics the codec to force the workflows to handle the error via its [go.temporal.io/sdk/worker.WorkflowPanicPolicy].
-// If the codec returns an error, we can get into non-determinism issues.
+// ioError handles an IO error according to the codec's configuration.
+//
+// By default it panics so that the Temporal worker's WorkflowPanicPolicy handles it,
+// avoiding non-determinism issues inside workflow functions.
 // See https://community.temporal.io/t/panicing-within-a-dataconverter-and-or-payloadcodec/19305
-func panicOnIOError(err error) {
-	panic(fmt.Errorf("large payload codec IO error: %v", err))
+//
+// When WithReturnErrorOnIOError is set it returns the error instead, which is safe for
+// callers outside a Temporal worker context.
+func (c *Codec) ioError(err error) error {
+	wrapped := fmt.Errorf("large payload codec IO error: %v", err)
+	if c.returnErrorOnIOError {
+		return wrapped
+	}
+	panic(wrapped)
 }

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -412,6 +412,25 @@ func Test_io_error_in_put_panics(t *testing.T) {
 	require.Fail(t, "expected panic but none occurred")
 }
 
+func Test_io_error_in_put_returns_error_with_option(t *testing.T) {
+	d := NewPutRejectingDriver()
+	srv := httptest.NewServer(server.NewHttpHandler(d))
+	defer srv.Close()
+
+	c := setUpWithOptions(t, "v2", srv, WithReturnErrorOnIOError())
+
+	payload := common.Payload{
+		Metadata: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+		Data: []byte("this is a longer message blah blah blah blah blah blah blah"),
+	}
+
+	_, err := c.Encode([]*common.Payload{&payload})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "large payload codec IO error")
+}
+
 func Test_io_error_in_get_panics(t *testing.T) {
 	d := NewGetRejectingDriver()
 	srv := httptest.NewServer(server.NewHttpHandler(d))
@@ -442,6 +461,36 @@ func Test_io_error_in_get_panics(t *testing.T) {
 	require.Fail(t, "expected panic but none occurred")
 }
 
+func Test_io_error_in_get_returns_error_with_option(t *testing.T) {
+	d := &memory.Driver{}
+	srv := httptest.NewServer(server.NewHttpHandler(d))
+	defer srv.Close()
+
+	// Encode with a normal codec so the payload is stored, then decode with
+	// a WithReturnErrorOnIOError codec backed by a driver that rejects gets.
+	encoder := setUpWithServer(t, "v2", srv, false)
+
+	rejectingDriver := NewGetRejectingDriver()
+	rejectingDriver.memoryDriver = d
+	rejectingSrv := httptest.NewServer(server.NewHttpHandler(rejectingDriver))
+	defer rejectingSrv.Close()
+	decoder := setUpWithOptions(t, "v2", rejectingSrv, WithReturnErrorOnIOError())
+
+	payload := common.Payload{
+		Metadata: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+		Data: []byte("this is a longer message blah blah blah blah blah blah blah"),
+	}
+
+	encodedPayloads, err := encoder.Encode([]*common.Payload{&payload})
+	require.NoError(t, err)
+
+	_, err = decoder.Decode(encodedPayloads)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "large payload codec IO error")
+}
+
 func setUp(t *testing.T, version string) (*httptest.Server, *Codec, storage.Driver) {
 	d := &memory.Driver{}
 	s := httptest.NewServer(server.NewHttpHandler(d))
@@ -460,6 +509,22 @@ func setUpWithServer(t *testing.T, version string, server *httptest.Server, with
 	if withDecodeOnly {
 		opts = append(opts, WithDecodeOnly())
 	}
+	c, err := New(opts...)
+	require.NoError(t, err)
+
+	c.version = version
+
+	return c
+}
+
+func setUpWithOptions(t *testing.T, version string, server *httptest.Server, extra ...Option) *Codec {
+	opts := []Option{
+		WithURL(server.URL),
+		WithHTTPClient(server.Client()),
+		WithNamespace("test"),
+		WithMinBytes(32),
+	}
+	opts = append(opts, extra...)
 	c, err := New(opts...)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Problem

The codec currently panics on IO errors unconditionally. This is intentional for Temporal workers — the SDK's `WorkflowPanicPolicy` catches the panic and handles it gracefully, avoiding non-determinism issues inside workflow functions.

However, callers **outside** a Temporal worker context have no such safety net:
- API handlers fetching a prior workflow result via `client.GetWorkflow().Get()`
- Goroutines spawned from activities that are not managed by the Temporal SDK

In those contexts a panic propagates uncaught and crashes the process. This has been observed in multiple services (e.g. `buildimpactanalysis-worker`, `buildimpactanalysis` rapid API), each of which has had to add per-call-site `defer recover()` wrappers as a workaround.

## Solution

Add a `WithReturnErrorOnIOError()` option. When set, `ioError` returns the wrapped error instead of panicking. The default behaviour (panic) is completely unchanged.

```go
codec, err := codec.New(
    codec.WithURL(lpsAddr),
    codec.WithNamespace(namespace),
    codec.WithReturnErrorOnIOError(), // safe for non-worker callers
)
```

## Tests

- Existing panic tests are unchanged and continue to pass
- Two new tests (`Test_io_error_in_put_returns_error_with_option`, `Test_io_error_in_get_returns_error_with_option`) verify the error-return path

🤖 Generated with [Claude Code](https://claude.com/claude-code)